### PR TITLE
Add style to inline code elements, fixes #7

### DIFF
--- a/src/templates/default/resources/_stylus/partials/_post.styl
+++ b/src/templates/default/resources/_stylus/partials/_post.styl
@@ -1,3 +1,8 @@
+code
+    background: #f5f2f0
+    font-family: Consolas, Monaco, 'Andale Mono', monospace
+    padding: 0 5px
+
 .postContent__title
     @extends $container
     margin: 1em 0 2em

--- a/src/templates/default/resources/css/main.css
+++ b/src/templates/default/resources/css/main.css
@@ -514,6 +514,11 @@ a:focus {
     max-width: 6rem;
   }
 }
+code {
+  background: #f5f2f0;
+  font-family: Consolas, Monaco, 'Andale Mono', monospace;
+  padding: 0 5px;
+}
 .postContent__title {
   margin: 1em 0 2em;
   display: flex;


### PR DESCRIPTION
See #7 

This is how inline code (e.g. `foo`) will be styled with this commit (click for zoom):
## ![inline code element in text](http://i.imgur.com/4dv6RJ6.png)

![inline code element in titles](http://i.imgur.com/khy6HYM.png)

As you can see, the inline code elements use the same background color and font family of the code blocks, this way it goes nicely inline with the current template.
