### PR TITLE
Remove the `module 'x' {}` syntax which no longer exists

### DIFF
--- a/src/posts/en/a-new-syntax-for-modules-in-es6.md
+++ b/src/posts/en/a-new-syntax-for-modules-in-es6.md
@@ -58,17 +58,6 @@ CommonJS modules does not consider browser environment and another prove is that
 
 Nowadays the **only way to define scope in Javascript is beyond functions**. As said, a new specification allows changing the language functionality. The module scope definition could be better solved out than in [Node.js, which still uses functions under the hood](https://github.com/joyent/node/blob/b55c9d68aa713e75ff5077cd425cbaafde010b92/src/node.js#L788-L791).
 
-ES6 specs brings a new exclusive syntax to define module scope. Throught syntax, it is possible to define more than one module in a single file without reaching out to functions that made us give up on AMD format. The result is a significative gain in expressivity:
-
-```javascript
-module 'foo' {
-    // Module code
-}
-module 'bar' {
-    // Module code
-}
-```
-
 ## Requesting dependencies (imports)
 
 CommonJS modules were conceived to require dependencies synchronously. **Script execution is blocked while a dependency is loaded**. Again, this approach does not bring any inconvenient to Node.js that has quick access to the filesystem.

--- a/src/posts/pt-br/a-new-syntax-for-modules-in-es6.md
+++ b/src/posts/pt-br/a-new-syntax-for-modules-in-es6.md
@@ -60,17 +60,6 @@ Os módulos CommonJS não consideram o ambiente dos navegadores, diferentes mód
 
 Atualmente, a **única maneira de definir escopos no JavaScript é através de funções**. Uma nova especificação permite mudar o funcionamento da linguagem. A necessária criação dos escopos poderia ser melhor resolvida que no [Node.js que ainda utiliza funções por baixo dos panos](https://github.com/joyent/node/blob/b55c9d68aa713e75ff5077cd425cbaafde010b92/src/node.js#L788-L791).
 
-A especificação ES6 traz consigo uma sintaxe exclusiva para definição de escopo de módulos. Através da sintaxe, é possível definir mais de um módulo em um mesmo arquivo sem apelar para o uso de funções que nos fizeram abrir mão do formato AMD. O resultado é um ganho significativo em expressividade, observe:
-
-```javascript
-module 'foo' {
-    // Module code
-}
-module 'bar' {
-    // Module code
-}
-```
-
 ## Requisição de dependências (imports)
 
 Os módulos CommonJS foram concebidos para requisitar as dependências sincronamente. **A execução do script é bloqueada enquanto uma dependência é carregada**. Novamente, esta abordagem não traz nenhum inconveniente para o Node.js que possui um acesso rápido ao sistema de arquivos.


### PR DESCRIPTION
As [commented](http://es6rocks.com/2014/07/a-new-syntax-for-modules-in-es6/#comment-1489230336) by @domenic.
