### PR TITLE
Fix footer overlap issue

### DIFF
--- a/_stylus/partials/_articles.styl
+++ b/_stylus/partials/_articles.styl
@@ -227,7 +227,7 @@ address {
 }
 
 .go-to-top-wrapper {
-    padding-bottom: 60px;
+    padding-bottom: 35px;
 }
 
 .main-article {

--- a/_stylus/partials/_footer.styl
+++ b/_stylus/partials/_footer.styl
@@ -6,7 +6,6 @@
     width: 100%;
     /*background-color: #0b0b0b;*/
     position: relative;
-    margin-top: -25px;
 
     a{
         &:hover{


### PR DESCRIPTION
Haven't tested this locally because of https://github.com/es6rocks/es6rocks.github.io/issues/51, but something to try out. The `.go-to-top-wrapper` in http://es6rocks.com/2015/01/temporal-dead-zone-tdz-demystified/ and other posts overlaps the links in the footer: 
![](https://s3.amazonaws.com/f.cl.ly/items/2r3j0G1H36242d1q2H40/Image%202015-02-12%20at%206.54.29%20PM.png)